### PR TITLE
Actually update dependencies this time.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,5 @@
 source "https://rubygems.org"
 
-gem "prometheus_exporter", "2.0.3"
-gem "rack", "2.2.4"
-gem "thin", "1.8.1"
+gem "prometheus_exporter"
+gem "rack"
+gem "thin"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,10 +3,10 @@ GEM
   specs:
     daemons (1.4.1)
     eventmachine (1.2.7)
-    prometheus_exporter (2.0.3)
+    prometheus_exporter (2.0.8)
       webrick
-    rack (2.2.4)
-    thin (1.8.1)
+    rack (2.2.8)
+    thin (1.8.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (>= 1, < 3)
@@ -21,9 +21,9 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  prometheus_exporter (= 2.0.3)
-  rack (= 2.2.4)
-  thin (= 1.8.1)
+  prometheus_exporter
+  rack
+  thin
 
 BUNDLED WITH
    2.4.19


### PR DESCRIPTION
In #68 I failed to spot the pinned versions in the Gemfile, so didn't actually fix the outdated dependencies.

Remove the version constraints from Gemfile (so we're just using Gemfile.lock like the rest of GOV.UK's Ruby apps) and re-run `bundle update`.

This should actually fix the Dependabot warnings this time (e.g. [this one](https://github.com/alphagov/govuk-replatform-test-app/security/dependabot/4)). D'oh.