### PR TITLE
Pin Ruby to minor version rather than patch.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ruby_version=3.2.2
+ARG ruby_version=3.2
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 


### PR DESCRIPTION
Saves having to update this by hand; we want the latest patch version by default.

Changing this now just as a test of the deployment automation after https://github.com/alphagov/govuk-helm-charts/pull/1428.