### PR TITLE
Add read contents permission to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,6 +30,7 @@ jobs:
       gitRef: ${{ inputs.gitRef || github.event.release.tag_name }}
     permissions:
       id-token: write
+      contents: read
   trigger-deploy:
     name: Trigger deploy to ${{ inputs.environment || 'integration' }}
     needs: build-and-publish-image


### PR DESCRIPTION
This permissions is needed by the reusable workflow to build and push the image.

https://github.com/alphagov/govuk-replatform-test-app/actions/runs/9191535891