### PR TITLE
Speculative fix for Read-only Error in Pod

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ PLATFORMS
   x86_64-darwin-20
   x86_64-darwin-22
   x86_64-linux
+  ruby
 
 DEPENDENCIES
   prometheus_exporter


### PR DESCRIPTION
## What?
This is a speculative fix for the Crash Loop of the Test App - some RO-FS errors are popping up in the logs. Re-generating the Gem Lock file is a suggested solution to this error.