### PR TITLE
Pass packages write permissions to build image workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      packages: write
   trigger-deploy:
     name: Trigger deploy to ${{ inputs.environment || 'integration' }}
     needs: build-and-publish-image


### PR DESCRIPTION
This is required by the build and push reusable workflow to push images to GitHub Packages.