### PR TITLE
Configure `bootsnap` gem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,14 @@ ARG ruby_version=3.4
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 
-FROM --platform=$TARGETPLATFORM $builder_image AS builder
+FROM $builder_image AS builder
 WORKDIR $APP_HOME
 COPY Gemfile* .ruby-version ./
 RUN bundle install
 COPY . .
+RUN bootsnap precompile --gemfile .
 
-FROM --platform=$TARGETPLATFORM $base_image
+FROM $base_image
 WORKDIR $APP_HOME
 COPY --from=builder $BUNDLE_PATH $BUNDLE_PATH
 COPY --from=builder $APP_HOME .

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gem "prometheus_exporter"
 gem "rack"
 gem "thin"
+gem 'bootsnap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,11 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    bootsnap (1.23.0)
+      msgpack (~> 1.2)
     daemons (1.4.1)
     eventmachine (1.2.7)
+    msgpack (1.8.0)
     prometheus_exporter (2.1.0)
       webrick
     rack (2.2.23)
@@ -23,6 +26,7 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
+  bootsnap
   prometheus_exporter
   rack
   thin


### PR DESCRIPTION
Description:
- In order to properly test whether Ruby 3.x builds work with https://github.com/alphagov/govuk-ruby-images/ we want to ensure this app serves as an adequate substitute. GOV.UK apps which run on Ruby 3.x have `bootsnap` configured so add it in here
- https://github.com/alphagov/govuk-infrastructure/issues/3961