### PR TITLE
Bump Gemfile.lock bundler version to 2.7.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,4 +32,4 @@ DEPENDENCIES
   thin
 
 BUNDLED WITH
-   2.5.9
+   2.7.2


### PR DESCRIPTION
Description:
- Bump `Gemfile.lock` Bundler version to 2.7.2
- https://github.com/alphagov/govuk-infrastructure/issues/3961