### PR TITLE
Downgrade to Ruby 3.3 and and Bundler 2.3.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ruby_version=3.4
+ARG ruby_version=3.3
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -32,4 +32,4 @@ DEPENDENCIES
   thin
 
 BUNDLED WITH
-   2.7.2
+   2.3.22


### PR DESCRIPTION
Description:
- https://github.com/alphagov/govuk-ruby-images/pull/201 caused an incident with [specialist-publisher](https://github.com/alphagov/specialist-publisher/actions/runs/23843446412/job/69510279731) which runs on Ruby 3.3 and Bundler 2.3.22
- To ensure that https://github.com/alphagov/govuk-ruby-images/pull/215 catches this error downgrade `govuk-replatform-test-app` to Ruby 3.3 and Bundler 2.3.22
- https://github.com/alphagov/govuk-infrastructure/issues/3961