### PR TITLE
Add Ruby version to README

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ruby_version=3.3
+ARG ruby_version=3.4
 ARG base_image=ghcr.io/alphagov/govuk-ruby-base:$ruby_version
 ARG builder_image=ghcr.io/alphagov/govuk-ruby-builder:$ruby_version
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ This is a very simple test app to help GOV.UK developers familiarise themselves 
 
 Navigate to the test app url on your browser and set the status parameter as the status response you want (e.g. `<test app url>?status=200`)
 
+## Build workflows
+
+This app is used by [govuk-ruby-images](https://github.com/alphagov/govuk-ruby-images/blob/main/.github/workflows/build-govuk-replatform-test-app.yaml) as part of a workflow to test the base and builder Ruby images. It is currently pinned to `Ruby 3.4` and `Bundler 2.3.22` to ensure that Ruby 3.x builds are tested. Ensure that this is always at the penultimate Ruby version.
+
 ## Run the app locally
 
 The app is intended to run on the GOV.UK Kubernetes clusters, but it is also possible to run it locally.


### PR DESCRIPTION
Description:
- Add information on why the app is pinned to Ruby 3.4 and Bundler 2.3.22 including the reusuable workflow used by govuk-ruby-images