### PR TITLE
Add `rake` gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,5 @@ source "https://rubygems.org"
 gem "prometheus_exporter"
 gem "rack"
 gem "thin"
+gem "rake"
 gem 'bootsnap', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     prometheus_exporter (2.1.0)
       webrick
     rack (2.2.23)
+    rake (13.4.2)
     thin (1.8.2)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
@@ -29,6 +30,7 @@ DEPENDENCIES
   bootsnap
   prometheus_exporter
   rack
+  rake
   thin
 
 BUNDLED WITH


### PR DESCRIPTION
Description:
- `rake` isn't available as an executable in the Dockerfile so add it so we can run `rake hello`
- https://github.com/alphagov/govuk-infrastructure/issues/4206