### PR TITLE
Create a failed job

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,11 @@
 desc "Outputs hello world"
 task :hello do
+  sleep(5)
   puts "Hello World!"
+end
+
+desc "Outputs failed"
+task :failed do
+  sleep(5)
+  abort "Failed! Exiting process"
 end


### PR DESCRIPTION
Description:
- Add a Rake task that fails so that we can test when a `Job` fails in https://github.com/alphagov/govuk-job-request-operator
- Delay both rake tasks by 5 seconds to allow for a delay between Job creation and Job success
- https://github.com/alphagov/govuk-infrastructure/issues/4206